### PR TITLE
feat: Reliable queuing in the cardano-backer

### DIFF
--- a/src/backer/backering.py
+++ b/src/backer/backering.py
@@ -302,27 +302,29 @@ class HttpEnd:
         cr = httping.parseCesrHttpRequest(req=req)
         serder = serdering.SerderKERI(sad=cr.payload, kind=eventing.Serials.json)
 
-        backer_identifiers = serder.ked["b"]
+        # Should check when create identifiers only
+        if serder.ked["t"] == "icp":
+            backer_identifiers = serder.ked["b"]
 
-        # Confirm registry backer
-        # raise exception when invalid registry backer or invalid identifier
-        if TraitCodex.Backers not in serder.ked["c"] or self.hab.pre not in backer_identifiers:
-            raise falcon.HTTPBadRequest(falcon.HTTP_400)
+            # Confirm registry backer
+            # raise exception when invalid registry backer or invalid identifier
+            if TraitCodex.Backers not in serder.ked["c"] or self.hab.pre not in backer_identifiers:
+                raise falcon.HTTPBadRequest(falcon.HTTP_400)
 
-        valid_backer_seals = 0
+            valid_backer_seals = 0
 
 
-        for key, item in enumerate(serder.ked["a"]):
-            if (
-                item["bi"]
-                and item["d"] == REGISTRAR_SEAL_SAID
-            ):
-                if backer_identifiers[key] == item["bi"]:
-                    valid_backer_seals += 1
-                    break
+            for key, item in enumerate(serder.ked["a"]):
+                if (
+                    item["bi"]
+                    and item["d"] == REGISTRAR_SEAL_SAID
+                ):
+                    if backer_identifiers[key] == item["bi"]:
+                        valid_backer_seals += 1
+                        break
 
-        if valid_backer_seals != len(backer_identifiers):
-            raise falcon.HTTPBadRequest(falcon.HTTP_400)
+            if valid_backer_seals != len(backer_identifiers):
+                raise falcon.HTTPBadRequest(falcon.HTTP_400)
 
         msg = bytearray(serder.raw)
         msg.extend(cr.attachments.encode("utf-8"))

--- a/src/backer/backering.py
+++ b/src/backer/backering.py
@@ -412,11 +412,6 @@ class MailboxIterable:
                     if self.ledger and topic == "/receipt":
                         try:
                             self.queue,push_to_queued(self.pre, msg)
-
-                            serder = serdering.SerderKERI(raw=msg)
-                            event = eventing.loadEvent(self.hab.db, self.pre, serder.saidb)
-                            self.ledger.publishEvent(event)
-                            
                         except Exception as e:
                             logger.error(f"ledger error: {e}")
                 self.topics[topic] = idx

--- a/src/backer/backering.py
+++ b/src/backer/backering.py
@@ -411,7 +411,7 @@ class MailboxIterable:
 
                     if self.ledger and topic == "/receipt":
                         try:
-                            self.queue,push_to_queued(self.pre, msg)
+                            self.queue.push_to_queued(self.pre, msg)
                         except Exception as e:
                             logger.error(f"ledger error: {e}")
                 self.topics[topic] = idx

--- a/src/backer/backering.py
+++ b/src/backer/backering.py
@@ -29,7 +29,7 @@ from keri.vdr import verifying, viring
 from keri.vdr.eventing import Tevery
 from keri.core import coring
 from .constants import REGISTRAR_SEAL_SAID
-from ... import queueing
+from backer import queueing
 
 logger = help.ogler.getLogger()
 

--- a/src/backer/backering.py
+++ b/src/backer/backering.py
@@ -29,6 +29,7 @@ from keri.vdr import verifying, viring
 from keri.vdr.eventing import Tevery
 from keri.core import coring
 from .constants import REGISTRAR_SEAL_SAID
+from ... import queueing
 
 logger = help.ogler.getLogger()
 
@@ -106,9 +107,11 @@ def setupBacker(hby, alias="backer", mbx=None, tcpPort=5631, httpPort=5632, ledg
         responses=rep.cues,
         queries=httpEnd.qrycues)
 
+    queueStart = queueing.Queueing(hab=hab)
+
     doers.extend(oobiRes)
     doers.extend([regDoer,
-                  directant, serverDoer, httpServerDoer, rep, witStart, *oobiery.doers])
+                  directant, serverDoer, httpServerDoer, rep, witStart, queueStart, *oobiery.doers])
 
     return doers
 
@@ -383,6 +386,7 @@ class MailboxIterable:
         self.retry = retry
         self.hab = hab
         self.ledger = ledger
+        self.queue = queueing.Queueing(hab=hab)
 
     def __iter__(self):
         self.start = self.end = time.perf_counter()
@@ -407,6 +411,8 @@ class MailboxIterable:
 
                     if self.ledger and topic == "/receipt":
                         try:
+                            self.queue,push_to_queued(self.pre, msg)
+
                             serder = serdering.SerderKERI(raw=msg)
                             event = eventing.loadEvent(self.hab.db, self.pre, serder.saidb)
                             self.ledger.publishEvent(event)

--- a/src/backer/cardaning.py
+++ b/src/backer/cardaning.py
@@ -44,8 +44,7 @@ class Cardano:
 
     def __init__(self, name='backer', hab=None, ks=None):
         self.name = name
-        self.pending_kel = bytearray()
-        self.timer = Timer(QUEUE_DURATION, self.flushQueue)
+        self.pending_kel = bytearray()        
         self.context = pycardano.OgmiosV6ChainContext()
         self.client = ogmios.Client()
 
@@ -64,7 +63,7 @@ class Cardano:
             self.fundAddress(self.spending_addr)
 
     def publishEvent(self, event: bytes):
-        self.pending_kel += event
+        self.pending_kel = event + self.pending_kel
 
     def flushQueue(self):
         try:

--- a/src/backer/cardaning.py
+++ b/src/backer/cardaning.py
@@ -63,32 +63,32 @@ class Cardano:
         else:
             self.fundAddress(self.spending_addr)
 
-    def publishEvent(self, event: bytearray):
-        self.pending_kel = event
-        self.flushQueue()
+    def publishEvent(self, event: bytes):
+        self.pending_kel += event
 
     def flushQueue(self):
         try:
-            # Build transaction
-            builder = pycardano.TransactionBuilder(self.context)
-            builder.add_input_address(self.spending_addr)
-            builder.add_output(pycardano.TransactionOutput(self.spending_addr, pycardano.Value.from_primitive([TRANSACTION_AMOUNT])))
+            if self.pending_kel:
+                # Build transaction
+                builder = pycardano.TransactionBuilder(self.context)
+                builder.add_input_address(self.spending_addr)
+                builder.add_output(pycardano.TransactionOutput(self.spending_addr, pycardano.Value.from_primitive([TRANSACTION_AMOUNT])))
+                self.pending_kel = bytes(self.pending_kel)
+                # Chunk size
+                # bytearrays is not accept
+                value = [self.pending_kel[i:i + 64] for i in range(0, len(self.pending_kel), 64)]
 
-            # Chunk size
-            # bytearrays is not accept
-            value = [self.pending_kel[i:i + 64] for i in range(0, len(self.pending_kel), 64)]
+                # Metadata. accept int key type
+                builder.auxiliary_data = pycardano.AuxiliaryData(pycardano.Metadata({1: value}))
 
-            # Metadata. accept int key type
-            builder.auxiliary_data = pycardano.AuxiliaryData(pycardano.Metadata({1: value}))
-
-            signed_tx = builder.build_and_sign([self.payment_signing_key],
-                                               change_address=self.spending_addr,
-                                               merge_change=True)
-            # Submit transaction
-            self.context.submit_tx(signed_tx.to_cbor())            
-        except Exception as e:
-            self.timer = Timer(90, self.flushQueue)
-            self.timer.start()
+                signed_tx = builder.build_and_sign([self.payment_signing_key],
+                                                change_address=self.spending_addr,
+                                                merge_change=True)
+                # Submit transaction
+                self.context.submit_tx(signed_tx.to_cbor())  
+                self.pending_kel = bytearray()
+        except Exception as e:    
+            logger.critical(f"Error: {e}")
 
     def getaddressBalance(self, addr):
         try:            

--- a/src/backer/cardaning.py
+++ b/src/backer/cardaning.py
@@ -67,10 +67,7 @@ class Cardano:
     def publishEvent(self, event: bytearray):
         # TODO: Change to the arrays
         self.pending_kel = event
-        if not self.timer.is_alive():
-            self.timer = Timer(90, self.flushQueue)
-            self.timer.start()
-
+        self.flushQueue()
 
     def flushQueue(self):
         try:            

--- a/src/backer/cardaning.py
+++ b/src/backer/cardaning.py
@@ -44,8 +44,7 @@ class Cardano:
 
     def __init__(self, name='backer', hab=None, ks=None):
         self.name = name
-        # TODO: pending_kel should change to array
-        self.pending_kel = None
+        self.pending_kel = bytearray()
         self.timer = Timer(QUEUE_DURATION, self.flushQueue)
         self.context = pycardano.OgmiosV6ChainContext()
         self.client = ogmios.Client()
@@ -65,12 +64,11 @@ class Cardano:
             self.fundAddress(self.spending_addr)
 
     def publishEvent(self, event: bytearray):
-        # TODO: Change to the arrays
         self.pending_kel = event
         self.flushQueue()
 
     def flushQueue(self):
-        try:            
+        try:
             # Build transaction
             builder = pycardano.TransactionBuilder(self.context)
             builder.add_input_address(self.spending_addr)
@@ -78,7 +76,6 @@ class Cardano:
 
             # Chunk size
             # bytearrays is not accept
-            self.pending_kel = bytes(self.pending_kel)
             value = [self.pending_kel[i:i + 64] for i in range(0, len(self.pending_kel), 64)]
 
             # Metadata. accept int key type
@@ -88,8 +85,7 @@ class Cardano:
                                                change_address=self.spending_addr,
                                                merge_change=True)
             # Submit transaction
-            dd = signed_tx.to_cbor()
-            self.context.submit_tx(signed_tx.to_cbor())
+            self.context.submit_tx(signed_tx.to_cbor())            
         except Exception as e:
             self.timer = Timer(90, self.flushQueue)
             self.timer.start()

--- a/src/backer/cli/backer.py
+++ b/src/backer/cli/backer.py
@@ -5,7 +5,6 @@ backer.cli.commands module
 """
 import multicommand
 from keri import help
-
 from keri.app import directing
 from backer.cli import commands
 

--- a/src/backer/cli/commands/start.py
+++ b/src/backer/cli/commands/start.py
@@ -87,14 +87,12 @@ def runBacker(name="backer", base="", alias="backer", bran="", tcp=5665, http=56
     hab = hby.habByName(name=alias)
     if hab is None:
         hab = hby.makeHab(name=alias, transferable=False)
-    if ledger == "cardano":
-        ldg = cardaning.Cardano(name=alias, hab=hab, ks=ks)
-        que = queueing.Queueing(hab=hab)
+
+    que = queueing.Queueing(hab=hab)
     backer = backering.setupBacker(alias=alias,
                                           hby=hby,
                                           tcpPort=tcp,
                                           httpPort=http,
-                                          ledger=ldg,
                                           queue=que)
     crl = crawling.Crawler(backer=backer)
     doers = [hbyDoer, crl]

--- a/src/backer/cli/commands/start.py
+++ b/src/backer/cli/commands/start.py
@@ -11,7 +11,7 @@ import logging
 from keri import __version__
 from keri import help
 from keri.app import directing, habbing, keeping
-from backer import backering
+from backer import backering, queueing
 from backer import cardaning
 from backer import crawling
 from keri.app.cli.common import existing
@@ -89,12 +89,13 @@ def runBacker(name="backer", base="", alias="backer", bran="", tcp=5665, http=56
         hab = hby.makeHab(name=alias, transferable=False)
     if ledger == "cardano":
         ldg = cardaning.Cardano(name=alias, hab=hab, ks=ks)
-
+        que = queueing.Queueing(hab=hab)
     backer = backering.setupBacker(alias=alias,
                                           hby=hby,
                                           tcpPort=tcp,
                                           httpPort=http,
-                                          ledger=ldg)
+                                          ledger=ldg,
+                                          queue=que)
     crl = crawling.Crawler(backer=backer)
     doers = [hbyDoer, crl]
 

--- a/src/backer/cli/commands/start.py
+++ b/src/backer/cli/commands/start.py
@@ -11,9 +11,9 @@ import logging
 from keri import __version__
 from keri import help
 from keri.app import directing, habbing, keeping
-from ... import backering
-from ... import cardaning
-from ... import crawling
+from backer import backering
+from backer import cardaning
+from backer import crawling
 from keri.app.cli.common import existing
 
 d = "Runs KERI backer controller"

--- a/src/backer/queueing.py
+++ b/src/backer/queueing.py
@@ -10,7 +10,6 @@ class Queueing(doing.Doer):
         self.name = name
         self.hab = hab
         # TODO: pending_kel should change to array
-        self.pending_kel = None
         self.ledger = cardaning.Cardano(name=name, hab=hab)
         # sub-dbs
         self.keldb_queued = subing.SerderSuber(db=hab.db, subkey="kel_queued")
@@ -28,8 +27,8 @@ class Queueing(doing.Doer):
         for (pre, said), serder in self.keldb_queued.getItemIter():
             event = eventing.loadEvent(self.hab.db, pre, serder.saidb)
             self.ledger.publishEvent(event=event)
-            self.keldb_queued.rem(keys=pre)
             self.keldb_published.pin(keys=pre, val=serder)
+            self.keldb_queued.rem(keys=pre)
 
     def recur(self, tyme=None):
         while True:

--- a/src/backer/queueing.py
+++ b/src/backer/queueing.py
@@ -1,7 +1,10 @@
 from hio import doing
+from keri import help
 from keri.db import subing
 from keri.core import serdering, eventing
 from ... import cardaning
+
+logger = help.ogler.getLogger()
 
 
 class Queueing(doing.Doer):
@@ -21,14 +24,19 @@ class Queueing(doing.Doer):
         doer call run
             get from queued
                 do publishEvent
-            deleted from queued
             create in published
+            deleted from queued
         """
-        for (pre, said), serder in self.keldb_queued.getItemIter():
-            event = eventing.loadEvent(self.hab.db, pre, serder.saidb)
-            self.ledger.publishEvent(event=event)
-            self.keldb_published.pin(keys=pre, val=serder)
-            self.keldb_queued.rem(keys=pre)
+        for (pre, ), serder in self.keldb_queued.getItemIter():
+            try:
+                event = eventing.loadEvent(self.hab.db, pre, serder.saidb)
+                self.ledger.publishEvent(event=event)
+                self.keldb_published.pin(keys=pre, val=serder)
+                self.keldb_queued.rem(keys=pre)
+            except Exception as e:
+                logger.error(str(e))
+                continue
+
 
     def recur(self, tyme=None):
         while True:

--- a/src/backer/queueing.py
+++ b/src/backer/queueing.py
@@ -1,0 +1,44 @@
+from hio import doing
+from keri.db import subing
+from keri.core import serdering, eventing
+from ... import cardaning
+
+
+class Queueing(doing.Doer):
+
+    def __init__(self, name='backer', hab=None):
+        self.name = name
+        self.hab = hab
+        # TODO: pending_kel should change to array
+        self.pending_kel = None
+        self.ledger = cardaning.Cardano(name=name, hab=hab)
+        # sub-dbs
+        self.keldb_queued = subing.SerderSuber(db=hab.db, subkey="kel_queued")
+        self.keldb_published = subing.SerderSuber(db=hab.db, subkey="kel_published")
+        self.tock = 10  # the job should run daily.
+
+    def publish(self):
+        """
+        doer call run
+            get from queued
+                do publishEvent
+            deleted from queued
+            create in published
+        """
+        for (pre, said), serder in self.keldb_queued.getItemIter():
+            event = eventing.loadEvent(self.hab.db, pre, serder.saidb)
+            self.ledger.publishEvent(event=event)
+            self.keldb_queued.rem(keys=pre)
+            self.keldb_published.pin(keys=pre, val=serder)
+
+    def recur(self, tyme=None):
+        while True:
+            self.publish()
+            yield self.tock
+
+    def push_to_queued(self, pre, msg):
+        """
+        push even to queued
+        """
+        serder = serdering.SerderKERI(raw=msg)
+        self.keldb_queued.pin(keys=pre, val=serder)

--- a/src/backer/queueing.py
+++ b/src/backer/queueing.py
@@ -1,4 +1,4 @@
-from hio import doing
+from hio.base import doing
 from keri import help
 from keri.db import subing
 from keri.core import serdering, eventing

--- a/src/backer/queueing.py
+++ b/src/backer/queueing.py
@@ -1,8 +1,8 @@
 from hio.base import doing
 from keri import help
 from keri.db import subing
-from keri.core import serdering, eventing
-from ... import cardaning
+from keri.core import serdering
+from backer import cardaning
 
 logger = help.ogler.getLogger()
 
@@ -13,7 +13,7 @@ class Queueing(doing.Doer):
         self.name = name
         self.hab = hab
         # TODO: pending_kel should change to array
-        self.ledger = cardaning.Cardano(name=name, hab=hab)
+        self.ledger = cardaning.Cardano(name=name, hab=hab, ks=hab.ks)
         # sub-dbs
         self.keldb_queued = subing.SerderSuber(db=hab.db, subkey="kel_queued")
         self.keldb_published = subing.SerderSuber(db=hab.db, subkey="kel_published")
@@ -29,8 +29,7 @@ class Queueing(doing.Doer):
         """
         for (pre, ), serder in self.keldb_queued.getItemIter():
             try:
-                event = eventing.loadEvent(self.hab.db, pre, serder.saidb)
-                self.ledger.publishEvent(event=event)
+                self.ledger.publishEvent(event=serder.raw)
                 self.keldb_published.pin(keys=pre, val=serder)
                 self.keldb_queued.rem(keys=pre)
             except Exception as e:

--- a/src/backer/queueing.py
+++ b/src/backer/queueing.py
@@ -35,6 +35,7 @@ class Queueing(doing.Doer):
             except Exception as e:
                 logger.error(str(e))
                 continue
+        self.ledger.flushQueue()
 
 
     def recur(self, tyme=None):

--- a/src/tests/test_queueing.py
+++ b/src/tests/test_queueing.py
@@ -1,43 +1,20 @@
 # -*- encoding: utf-8 -*-
 """
-tests.core.test_eventing module
+src.tests.test_queueing module
 
 """
-import os
-
-import blake3
-import pysodium
-import pytest
 import requests
 
 from hio.help import Hict
-from keri import kering
-from keri.app import habbing, keeping
+from keri.app import habbing
 from keri.app.keeping import openKS, Manager
-from keri.core import coring, eventing, parsing, serdering
-from keri.core.coring import (Diger, MtrDex, Matter, IdrDex, Indexer,
-                              CtrDex, Counter, Salter, Siger, Cigar,
-                              Seqner, Verfer, Signer, Prefixer,
-                              generateSigners, IdxSigDex, DigDex)
-from keri.core.eventing import Kever, Kevery
-from keri.core.eventing import (SealDigest, SealRoot, SealBacker,
-                                SealEvent, SealLast, StateEvent, StateEstEvent)
-from keri.core.eventing import (TraitDex, LastEstLoc, Serials, versify,
-                                simple, ample)
-from keri.core.eventing import (deWitnessCouple, deReceiptCouple, deSourceCouple,
-                                deReceiptTriple,
-                                deTransReceiptQuadruple, deTransReceiptQuintuple)
-from keri.core.eventing import (incept, rotate, interact, receipt, query,
-                                delcept, deltate, state, messagize)
+from keri.core import coring, eventing, serdering
+from keri.core.coring import (Salter, Siger)
+from keri.core.eventing import query
 from keri.core import serdering
-
-from keri.db import dbing, basing
 from keri.db.basing import openDB
-from keri.db.dbing import dgKey, snKey
-from keri.kering import (ValidationError, DerivationError, Ilks)
-
 from keri import help
-from src.backer import queueing
+from backer import queueing
 
 
 def test_push_to_queued():
@@ -45,42 +22,7 @@ def test_push_to_queued():
     salter = coring.Salter(raw=salt)
 
     with habbing.openHby(name="keria", salt=salter.qb64, temp=True) as hby:
-        hab = hby.makeHab("test01")
-        icp = hab.makeOwnInception()
-
-        icp = {
-            "v": "KERI10JSON00012b_",
-            "t": "icp",
-            "d": "EIvqOceOSGCMW4Ls-Wdi6t4K3RjKZU_DcHC_Q2w2jNs9",
-            "i": "EIvqOceOSGCMW4Ls-Wdi6t4K3RjKZU_DcHC_Q2w2jNs9",
-            "s": "0",
-            "kt": "1",
-            "k": ["DCwn62HEdsIbb0Tf-xTTR3fxZMQspc4iNbghK93Tfv1m"],
-            "nt": "1",
-            "n": ["EDzxxCBaWkzJ2Azn5HS50DZjslp-HMPeG6vGEm4AW168"],
-            "bt": "0",
-            "b": [],
-            "c": [],
-            "a": [],
-        }
-
-        serder = serdering.SerderKERI(sad=icp, kind=eventing.Serials.json)
-        msg = serder.raw
-
-        queue = queueing.Queueing(hab=hab)
-        queue.push_to_queued(hab.pre, msg)
-
-        # Verify push to queue then get serder from keys
-        assert queue.keldb_queued.get(hab.pre).raw == serder.raw
-
-
-def test_push_to_queued():
-    salt = b"0123456789abcdef"
-    salter = coring.Salter(raw=salt)
-
-    with habbing.openHby(name="keria", salt=salter.qb64, temp=True) as hby:
-        hab = hby.makeHab("test01")
-        icp = hab.makeOwnInception()
+        hab = hby.makeHab("test01", transferable=False)
 
         icp = {
             "v": "KERI10JSON00012b_",
@@ -112,10 +54,8 @@ def test_fetch_push_t():
     salt = b"0123456789abcdef"
     salter = coring.Salter(raw=salt)
 
-    with habbing.openHby(name="keria", salt=salter.qb64, temp=True) as hby:
-        hab = hby.makeHab("test01")
-        icp = hab.makeOwnInception()
-
+    with habbing.openHby(name="keria", salt=salter.qb64, temp=True) as hby:     
+        hab = hby.makeHab("test01", transferable=False)
         icp = {
             "v": "KERI10JSON00012b_",
             "t": "icp",
@@ -155,40 +95,24 @@ def test_fetch_push_t():
 
 def test_http_call():
     salter = Salter(raw=b'0123456789abcdef')
-    vsn = vesn = 0  # sn and last establishment sn = esn
-    salter = Salter(raw=b'0123456789abcdef')
+
     with openDB(name="edy") as db, openKS(name="edy") as ks, habbing.openHby(name="keria", salt=salter.qb64, temp=True) as hby:
         # Init key pair manager
-        mgr = Manager(ks=ks, salt=salter.qb64)
         hab = hby.makeHab("test02")
-
         mgr = Manager(ks=ks, salt=salter.qb64)
-        verfers, digers = mgr.incept(icount=1, ncount=0, transferable=True, stem="C")
-        #
-        # # Test with inception message
-        # serder = incept(keys=[verfers[0].qb64], code=MtrDex.Blake3_256)
-
+        verfers, _ = mgr.incept(icount=1, ncount=0, transferable=True, stem="C")
         qry = hab.query(pre=hab.pre, src=hab.pre, route="/log")
         serder = serdering.SerderKERI(raw=qry)
-        # Test with query message
-        ked = serder.ked
-
         sigers = mgr.sign(ser=serder.raw, verfers=verfers)  # default indexed True
         assert isinstance(sigers[0], Siger)
-        msg = messagize(serder, sigers=sigers)
-
-        srdr = serdering.SerderKERI(raw=qry)
 
         qserder = query(route="log",
                         query=dict(i='DAvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI'),
                         stamp=help.helping.DTS_BASE_0)
-
         msg = qserder.raw
-
         CESR_CONTENT_TYPE = "application/cesr+json"
         CESR_ATTACHMENT_HEADER = "CESR-ATTACHMENT"
         CESR_DESTINATION_HEADER = "CESR-DESTINATION"
-
         attachment = b'-VAj-HABEIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3-AABAAB6P97k'
 
         headers = Hict(

--- a/src/tests/test_queueing.py
+++ b/src/tests/test_queueing.py
@@ -8,7 +8,9 @@ import os
 import blake3
 import pysodium
 import pytest
+import requests
 
+from hio.help import Hict
 from keri import kering
 from keri.app import habbing, keeping
 from keri.app.keeping import openKS, Manager
@@ -149,3 +151,59 @@ def test_fetch_push_t():
         # Verify event published and keldb_published had events from keldb_queued
         keldb_published = [(pre, serder) for (pre,), serder in queue.keldb_published.getItemIter()]
         assert keldb_published != []
+
+
+def test_http_call():
+    salter = Salter(raw=b'0123456789abcdef')
+    vsn = vesn = 0  # sn and last establishment sn = esn
+    salter = Salter(raw=b'0123456789abcdef')
+    with openDB(name="edy") as db, openKS(name="edy") as ks, habbing.openHby(name="keria", salt=salter.qb64, temp=True) as hby:
+        # Init key pair manager
+        mgr = Manager(ks=ks, salt=salter.qb64)
+        hab = hby.makeHab("test02")
+
+        mgr = Manager(ks=ks, salt=salter.qb64)
+        verfers, digers = mgr.incept(icount=1, ncount=0, transferable=True, stem="C")
+        #
+        # # Test with inception message
+        # serder = incept(keys=[verfers[0].qb64], code=MtrDex.Blake3_256)
+
+        qry = hab.query(pre=hab.pre, src=hab.pre, route="/log")
+        serder = serdering.SerderKERI(raw=qry)
+        # Test with query message
+        ked = serder.ked
+
+        sigers = mgr.sign(ser=serder.raw, verfers=verfers)  # default indexed True
+        assert isinstance(sigers[0], Siger)
+        msg = messagize(serder, sigers=sigers)
+
+        srdr = serdering.SerderKERI(raw=qry)
+
+        qserder = query(route="log",
+                        query=dict(i='DAvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI'),
+                        stamp=help.helping.DTS_BASE_0)
+
+        msg = qserder.raw
+
+        CESR_CONTENT_TYPE = "application/cesr+json"
+        CESR_ATTACHMENT_HEADER = "CESR-ATTACHMENT"
+        CESR_DESTINATION_HEADER = "CESR-DESTINATION"
+
+        attachment = b'-VAj-HABEIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3-AABAAB6P97k'
+
+        headers = Hict(
+            [
+                ("Content-Type", CESR_CONTENT_TYPE),
+                ("Content-Length", str(len(msg))),
+                (CESR_ATTACHMENT_HEADER, attachment),
+                (
+                    CESR_DESTINATION_HEADER,
+                    "BD27gP7-sD8XSr7_tTo54aNIRzPBJGX7GvRUVojfYL2H",
+                ),
+            ]
+        )
+
+        res = requests.request(
+            "POST", "http://localhost:5666/", headers=headers, data=msg
+        )
+        assert res.status_code == 204

--- a/src/tests/test_queueing.py
+++ b/src/tests/test_queueing.py
@@ -56,7 +56,8 @@ def test_fetch_push_t():
 
     with habbing.openHby(name="keria", salt=salter.qb64, temp=True) as hby:     
         hab = hby.makeHab("test01", transferable=False)
-        icp = {
+        
+        icp_1 = {
             "v": "KERI10JSON00012b_",
             "t": "icp",
             "d": "EIvqOceOSGCMW4Ls-Wdi6t4K3RjKZU_DcHC_Q2w2jNs9",
@@ -72,11 +73,32 @@ def test_fetch_push_t():
             "a": [],
         }
 
-        serder = serdering.SerderKERI(sad=icp, kind=eventing.Serials.json)
-        msg = serder.raw
+        icp_2 = {
+            "v": "KERI10JSON0000fd_",
+            "t": "icp",
+            "d": "EP-4PeQ-5j1CG4MW2OrPQWbRcQ53IxEeiwqWP6IfXoom",
+            "i": "BCwn62HEdsIbb0Tf-xTTR3fxZMQspc4iNbghK93Tfv1m",
+            "s": "0",
+            "kt": "1",
+            "k": [
+                "BCwn62HEdsIbb0Tf-xTTR3fxZMQspc4iNbghK93Tfv1m"
+            ],
+            "nt": "0",
+            "n": [],
+            "bt": "0",
+            "b": [],
+            "c": [],
+            "a": []
+            }
+
+        serder_1 = serdering.SerderKERI(sad=icp_1, kind=eventing.Serials.json)
+        msg_1 = serder_1.raw
+        serder_2 = serdering.SerderKERI(sad=icp_2, kind=eventing.Serials.json)
+        msg_2 = serder_2.raw
 
         queue = queueing.Queueing(hab=hab)
-        queue.push_to_queued(hab.pre, msg)
+        queue.push_to_queued(f"{hab.pre}_1", msg_1)
+        queue.push_to_queued(f"{hab.pre}_2", msg_2)
 
         # Verify keldb_queued had events
         keldb_queued_items = [(pre, serder) for (pre,), serder in queue.keldb_queued.getItemIter()]

--- a/src/tests/test_queueing.py
+++ b/src/tests/test_queueing.py
@@ -1,0 +1,273 @@
+# -*- encoding: utf-8 -*-
+"""
+tests.core.test_eventing module
+
+"""
+import os
+
+import blake3
+import pysodium
+import pytest
+
+from keri import kering
+from keri.app import habbing, keeping
+from keri.app.keeping import openKS, Manager
+from keri.core import coring, eventing, parsing, serdering
+from keri.core.coring import (Diger, MtrDex, Matter, IdrDex, Indexer,
+                              CtrDex, Counter, Salter, Siger, Cigar,
+                              Seqner, Verfer, Signer, Prefixer,
+                              generateSigners, IdxSigDex, DigDex)
+from keri.core.eventing import Kever, Kevery
+from keri.core.eventing import (SealDigest, SealRoot, SealBacker,
+                                SealEvent, SealLast, StateEvent, StateEstEvent)
+from keri.core.eventing import (TraitDex, LastEstLoc, Serials, versify,
+                                simple, ample)
+from keri.core.eventing import (deWitnessCouple, deReceiptCouple, deSourceCouple,
+                                deReceiptTriple,
+                                deTransReceiptQuadruple, deTransReceiptQuintuple)
+from keri.core.eventing import (incept, rotate, interact, receipt, query,
+                                delcept, deltate, state, messagize)
+from keri.core import serdering
+
+from keri.db import dbing, basing
+from keri.db.basing import openDB
+from keri.db.dbing import dgKey, snKey
+from keri.kering import (ValidationError, DerivationError, Ilks)
+
+from keri import help
+from keri.help import helping
+
+logger = help.ogler.getLogger()
+
+
+def test_reload_kever(mockHelpingNowUTC):
+    """
+    Test reload Kever from keystate state message
+    """
+
+    with habbing.openHby(name="nat", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as natHby:
+        # setup Nat's habitat using default salt multisig already incepts
+        natHab = natHby.makeHab(name="nat", isith='2', icount=3)
+        assert natHab.name == 'nat'
+        assert natHab.ks == natHby.ks
+        assert natHab.db == natHby.db
+        assert natHab.kever.prefixer.transferable
+        assert natHab.db.opened
+        assert natHab.pre in natHab.kevers
+        assert natHab.pre in natHab.prefixes
+        assert natHab.db.path.endswith("/keri/db/test/nat")
+        path = natHab.db.path  # save for later
+
+        # Create series of events for Nat
+        natHab.interact()
+        natHab.rotate()
+        natHab.interact()
+        natHab.interact()
+        natHab.interact()
+        natHab.interact()
+
+        assert natHab.kever.sn == 6
+        assert natHab.kever.fn == 6
+        assert natHab.kever.serder.said == 'EA3QbTpV15MvLSXHSedm4lRYdQhmYXqXafsD4i75B_yo'
+        ldig = bytes(natHab.db.getKeLast(dbing.snKey(natHab.pre, natHab.kever.sn)))
+        assert ldig == natHab.kever.serder.saidb
+        serder = serdering.SerderKERI(raw=bytes(natHab.db.getEvt(dbing.dgKey(natHab.pre, ldig))))
+        assert serder.said == natHab.kever.serder.said
+        nstate = natHab.kever.state()
+
+        state =natHab.db.states.get(keys=natHab.pre)  # key state record
+        assert state._asjson() == (b'{"vn":[1,0],"i":"EBm9JqQKS4a3EYv5I7BmAPiwhdSQvFAOpqe0dgk3kgH_","s":"6","p":"'
+                            b'ED_HpKSCQJoeGxHYjPRD2tgUhbIrLf6fH3e3xJFSq2dL","d":"EA3QbTpV15MvLSXHSedm4lRYd'
+                            b'QhmYXqXafsD4i75B_yo","f":"6","dt":"2021-01-01T00:00:00.000000+00:00","et":"i'
+                            b'xn","kt":"2","k":["DCORPGaoMtI_RyJFUTIzk0xdza_z6sBQ2e2wzYtEAs3s","DNjSHBbYJa'
+                            b'aUKJuPd34n7SRYiZHirwvW-QiHRtfRvBh4","DN-hL9CKn6WdsINEG207T4pSdjaMIxU9SKhfeeH'
+                            b'CwfvT"],"nt":"2","n":["EGZ9WHJPgrvDpe08gJpEZ8Gz-rcy72ZG7Tey0PS2CrXY","EO_z0O'
+                            b'FTUZ1pmfxj-VnQJcsYFdIVq2tWkN9nUWRxQab_","EMeWMAZpVy7IX6yl4F2t-WoUCaRFZ-0g5dx'
+                            b'_LLoEywhx"],"bt":"0","b":[],"c":[],"ee":{"s":"2","d":"EJ7s1vk30hWK_l-exQtzj4'
+                            b'P5u_wIzki1drVR4FAKDbEW","br":[],"ba":[]},"di":""}')
+        assert state.f == '6'
+        assert state == nstate
+
+        # now create new Kever with state
+        kever = eventing.Kever(state=state, db=natHby.db)
+        assert kever.sn == 6
+        assert kever.fn == 6
+        assert kever.serder.ked == natHab.kever.serder.ked
+        assert kever.serder.said == natHab.kever.serder.said
+
+        kstate = kever.state()
+        assert kstate == state
+        assert state._asjson() == (b'{"vn":[1,0],"i":"EBm9JqQKS4a3EYv5I7BmAPiwhdSQvFAOpqe0dgk3kgH_","s":"6","p":"'
+                            b'ED_HpKSCQJoeGxHYjPRD2tgUhbIrLf6fH3e3xJFSq2dL","d":"EA3QbTpV15MvLSXHSedm4lRYd'
+                            b'QhmYXqXafsD4i75B_yo","f":"6","dt":"2021-01-01T00:00:00.000000+00:00","et":"i'
+                            b'xn","kt":"2","k":["DCORPGaoMtI_RyJFUTIzk0xdza_z6sBQ2e2wzYtEAs3s","DNjSHBbYJa'
+                            b'aUKJuPd34n7SRYiZHirwvW-QiHRtfRvBh4","DN-hL9CKn6WdsINEG207T4pSdjaMIxU9SKhfeeH'
+                            b'CwfvT"],"nt":"2","n":["EGZ9WHJPgrvDpe08gJpEZ8Gz-rcy72ZG7Tey0PS2CrXY","EO_z0O'
+                            b'FTUZ1pmfxj-VnQJcsYFdIVq2tWkN9nUWRxQab_","EMeWMAZpVy7IX6yl4F2t-WoUCaRFZ-0g5dx'
+                            b'_LLoEywhx"],"bt":"0","b":[],"c":[],"ee":{"s":"2","d":"EJ7s1vk30hWK_l-exQtzj4'
+                            b'P5u_wIzki1drVR4FAKDbEW","br":[],"ba":[]},"di":""}')
+
+    assert not os.path.exists(natHby.ks.path)
+    assert not os.path.exists(natHby.db.path)
+
+    """End Test"""
+
+
+def test_load_event(mockHelpingNowUTC):
+    with habbing.openHby(name="tor", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as torHby, \
+         habbing.openHby(name="wil", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as wilHby, \
+         habbing.openHby(name="wan", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as wanHby, \
+         habbing.openHby(name="tee", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as teeHby:
+
+        wanKvy = Kevery(db=wanHby.db, lax=False, local=False)
+        torKvy = Kevery(db=torHby.db, lax=False, local=False)
+
+        # Create Wan the witness
+        wanHab = wanHby.makeHab(name="wan", transferable=False)
+        assert wanHab.pre == "BAbSj3jfaeJbpuqg0WtvHw31UoRZOnN_RZQYBwbAqteP"
+        msg = wanHab.makeOwnEvent(sn=0)
+        parsing.Parser().parse(ims=msg, kvy=torKvy)
+        assert wanHab.pre in torKvy.kevers
+
+        # Create Wil the witness, we'll use him later
+        wilHab = wilHby.makeHab(name="wil", transferable=False)
+
+        # Create Tor the delegaTOR and pass to witness Wan
+        torHab = torHby.makeHab(name="tor", icount=1, isith='1', ncount=1, nsith='1', wits=[wanHab.pre], toad=1)
+        assert torHab.pre == "EBOVJXs0trI76PRfvJB2fsZ56PrtyR6HrUT9LOBra8VP"
+        torIcp = torHab.makeOwnEvent(sn=0)
+        assert torHab.pre in torHab.kvy.kevers
+
+        # Try to load event before Wan has seen it
+        with pytest.raises(ValueError):
+            _ = eventing.loadEvent(wanHab.db, torHab.pre, torHab.pre)
+
+        # tor events are locallyWitnessed by wan so must process as local
+        parsing.Parser().parse(ims=bytearray(torIcp), kvy=wanHab.kvy, local=True) # process as local
+
+        wanHab.processCues(wanHab.kvy.cues)  # process cue returns rct msg
+        evt = eventing.loadEvent(wanHab.db, torHab.pre, torHab.pre)
+        assert evt == {'ked': {'a': [],
+                               'b': ['BAbSj3jfaeJbpuqg0WtvHw31UoRZOnN_RZQYBwbAqteP'],
+                               'bt': '1',
+                               'c': [],
+                               'd': 'EBOVJXs0trI76PRfvJB2fsZ56PrtyR6HrUT9LOBra8VP',
+                               'i': 'EBOVJXs0trI76PRfvJB2fsZ56PrtyR6HrUT9LOBra8VP',
+                               'k': ['DDgZRj4y6XmkeCsjxLQ-WeAU_U0D3ttTBHW-yicX9hjT'],
+                               'kt': '1',
+                               'n': ['ED9aiBH7JDgWIgPU1bEXDx8XDFPCWKQilDNyw9W1sCl_'],
+                               'nt': '1',
+                               's': '0',
+                               't': 'icp',
+                               'v': 'KERI10JSON000159_'},
+                       'receipts': {},
+                       'signatures': [{'index': 0,
+                                       'signature': 'AAAa36fZASpQeSPn6cEcDMuXRCpDqjXbQ0Q6PqOXB_uktcuANR8rsRdpgB3A87XWeU'
+                                                    'QMB0MrWxUE-2bcjq5JJtMP'}],
+                       'stored': True,
+                       'timestamp': '2021-01-01T00:00:00.000000+00:00',
+                       'witness_signatures': [{'index': 0,
+                                               'signature': 'AAAU3Kk_Sgd_r4NX4MyE33-eAxM5fUS0WxIyId8YJ-wphNxMT5wI1Mz540'
+                                                            'EjYZRkrnty3VfkYhMv-XkGJuY-JWQI'}],
+                       'witnesses': ['BAbSj3jfaeJbpuqg0WtvHw31UoRZOnN_RZQYBwbAqteP']}
+
+        # Create Tee the delegaTEE and pass to witness Wan
+        teeHab = teeHby.makeHab(name="tee", delpre=torHab.pre, icount=1, isith='1', ncount=1, nsith='1',
+                                wits=[wanHab.pre], toad=1)
+        assert teeHab.pre == "EDnrWpxagMvr5BBCwCOh3q5M9lvurboZ66vxR-GnIgQo"
+        teeIcp = teeHab.makeOwnEvent(sn=0)
+
+        # Anchor Tee's inception event in Tor's KEL
+        ixn = torHab.interact(data=[dict(i=teeHab.pre, s='0', d=teeHab.kever.serder.said)])
+        parsing.Parser().parse(ims=bytearray(ixn), kvy=wanHab.kvy, local=True)  # give to wan must be local
+        wanHab.processCues(wanHab.kvy.cues)  # process cue returns rct msg
+
+        evt = eventing.loadEvent(wanHab.db, torHab.pre, torHab.kever.serder.said)
+        assert evt == {'ked': {'a': [{'d': 'EDnrWpxagMvr5BBCwCOh3q5M9lvurboZ66vxR-GnIgQo',
+                                      'i': 'EDnrWpxagMvr5BBCwCOh3q5M9lvurboZ66vxR-GnIgQo',
+                                      's': '0'}],
+                               'd': 'EF7pHYN6XABC9znRdzprt5frW-MMry9rfrCI-_t5Y8VD',
+                               'i': 'EBOVJXs0trI76PRfvJB2fsZ56PrtyR6HrUT9LOBra8VP',
+                               'p': 'EBOVJXs0trI76PRfvJB2fsZ56PrtyR6HrUT9LOBra8VP',
+                               's': '1',
+                               't': 'ixn',
+                               'v': 'KERI10JSON00013a_'},
+                       'receipts': {},
+                       'signatures': [{'index': 0,
+                                       'signature': 'AABw4jnfadT8aCwyGX2rDtOV8ojW4w4kVehFoJu_p6TzRpsayZ-cibTM_2iZfHVjWx'
+                                                    'zcIUbP2ibq6cVbVcOcNHsF'}],
+                       'stored': True,
+                       'timestamp': '2021-01-01T00:00:00.000000+00:00',
+                       'witness_signatures': [{'index': 0,
+                                               'signature': 'AABBQIanzXTUfATO36Q_ZzXSE4x2OlxC0MnOuyaUBE4bJhdHhV0f7qPIu5'
+                                                            'xClEH2C5AgWgLRPlQ-qo98qJHhIr0B'}],
+                       'witnesses': []}
+
+        # Add seal source couple to Tee's inception before sending to Wan
+        counter = coring.Counter(code=coring.CtrDex.SealSourceCouples,
+                                 count=1)
+        teeIcp.extend(counter.qb64b)
+        seqner = coring.Seqner(sn=torHab.kever.sn)
+        teeIcp.extend(seqner.qb64b)
+        teeIcp.extend(torHab.kever.serder.saidb)
+
+        # Endorse Tee's inception event with Tor's Hab just so we have trans receipts
+        rct = torHab.receipt(serder=teeHab.kever.serder)
+        nrct = wilHab.receipt(serder=teeHab.kever.serder)
+
+        # Now Wan should be ready for Tee's inception
+        parsing.Parser().parse(ims=bytearray(teeIcp), kvy=wanKvy, local=True)  # local
+        parsing.Parser().parse(ims=bytearray(rct), kvy=wanHab.kvy, local=True) # local
+        parsing.Parser().parse(ims=bytearray(nrct), kvy=wanHab.kvy, local=True)  # local
+        # ToDo XXXX fix it so cues are durable in db so can process cues from
+        # both and remote sources
+        wanHab.processCues(wanHab.kvy.cues)  # process cue returns rct msg
+        wanHab.processCues(wanKvy.cues)  # process cue returns rct msg
+
+        # Endorse Tee's inception event with Wan's Hab just so we have non-trans receipts
+
+        evt = eventing.loadEvent(wanHab.db, teeHab.pre, teeHab.pre)
+        assert evt == {'ked': {'a': [],
+                               'b': ['BAbSj3jfaeJbpuqg0WtvHw31UoRZOnN_RZQYBwbAqteP'],
+                               'bt': '1',
+                               'c': [],
+                               'd': 'EDnrWpxagMvr5BBCwCOh3q5M9lvurboZ66vxR-GnIgQo',
+                               'di': 'EBOVJXs0trI76PRfvJB2fsZ56PrtyR6HrUT9LOBra8VP',
+                               'i': 'EDnrWpxagMvr5BBCwCOh3q5M9lvurboZ66vxR-GnIgQo',
+                               'k': ['DLDlVl1H2Q138A5tftVRpyy834ejsY33BB71kXLRNP2h'],
+                               'kt': '1',
+                               'n': ['EBTtZqMkJOO4nf3cCt6SdezwkoCKtx2fGUKHeFApj_Yx'],
+                               'nt': '1',
+                               's': '0',
+                               't': 'dip',
+                               'v': 'KERI10JSON00018d_'},
+                       'receipts': {'nontransferable': [{'prefix': 'BEXrSXVksXpnfno_Di6RBX2Lsr9VWRAihjLhowfjNOQQ',
+                                                         'signature': '0BCQOeNT3mwAHxh6mYU9K_B2VmbtjJh7_8115k4JrBPR3c4'
+                                                                      '3jUSO197H2J73vWMi61qzOovNkSWQbnRx3NFnrk8I'}],
+                                    'transferable': [{'prefix': 'EBOVJXs0trI76PRfvJB2fsZ56PrtyR6HrUT9LOBra8VP',
+                                                      'said': 'EBOVJXs0trI76PRfvJB2fsZ56PrtyR6HrUT9LOBra8VP',
+                                                      'sequence': '0AAAAAAAAAAAAAAAAAAAAAAA',
+                                                      'signature': 'AADGbcmUNw_SX7OVNX-PQYl41UZx_pgJXHOoMWrcfmCDGgkc1-'
+                                                                   'MqXJjMD9S9moJ-lpPL9-AiXgITemMZL_QYGzIA'}]},
+                       'signatures': [{'index': 0,
+                                       'signature': 'AAC1-NTntZ0xkgHwooNcKxe9G4XC-rgkSryVz0B_QrZR2kkv4IKi7DMkfMBd4Eck-'
+                                                    '2NAi0DMuZeXnlvch6ZP0coO'}],
+                       'source_seal': {'said': 'EF7pHYN6XABC9znRdzprt5frW-MMry9rfrCI-_t5Y8VD',
+                                       'sequence': 1},
+                       'stored': True,
+                       'timestamp': '2021-01-01T00:00:00.000000+00:00',
+                       'witness_signatures': [{'index': 0,
+                                               'signature': 'AABPMW3J1iZyMC-elPOkdIhddhZB_BJYHTdYv5SxcrOfJL_5igDVB6zKD'
+                                                            'AQiTj_cNa7oP-l6xSRRxwlHDwqgSwcB'}],
+                       'witnesses': ['BAbSj3jfaeJbpuqg0WtvHw31UoRZOnN_RZQYBwbAqteP']}
+
+    """End Test"""
+
+
+if __name__ == "__main__":
+    # pytest.main(['-vv', 'test_eventing.py::test_keyeventfuncs'])
+    #test_process_manual()
+    #test_keyeventsequence_0()
+    #test_process_transferable()
+    #test_messagize()
+    test_direct_mode()

--- a/src/tests/test_queueing.py
+++ b/src/tests/test_queueing.py
@@ -37,9 +37,6 @@ from keri.kering import (ValidationError, DerivationError, Ilks)
 from keri import help
 from src.backer import queueing
 
-logger = help.ogler.getLogger()
-
-
 
 def test_push_to_queued():
     salt = b"0123456789abcdef"

--- a/src/tests/test_queueing.py
+++ b/src/tests/test_queueing.py
@@ -35,239 +35,42 @@ from keri.db.dbing import dgKey, snKey
 from keri.kering import (ValidationError, DerivationError, Ilks)
 
 from keri import help
-from keri.help import helping
+from src.backer import queueing
 
 logger = help.ogler.getLogger()
 
 
-def test_reload_kever(mockHelpingNowUTC):
-    """
-    Test reload Kever from keystate state message
-    """
 
-    with habbing.openHby(name="nat", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as natHby:
-        # setup Nat's habitat using default salt multisig already incepts
-        natHab = natHby.makeHab(name="nat", isith='2', icount=3)
-        assert natHab.name == 'nat'
-        assert natHab.ks == natHby.ks
-        assert natHab.db == natHby.db
-        assert natHab.kever.prefixer.transferable
-        assert natHab.db.opened
-        assert natHab.pre in natHab.kevers
-        assert natHab.pre in natHab.prefixes
-        assert natHab.db.path.endswith("/keri/db/test/nat")
-        path = natHab.db.path  # save for later
+def test_push_to_queued():
+    salt = b"0123456789abcdef"
+    salter = coring.Salter(raw=salt)
 
-        # Create series of events for Nat
-        natHab.interact()
-        natHab.rotate()
-        natHab.interact()
-        natHab.interact()
-        natHab.interact()
-        natHab.interact()
+    with habbing.openHby(name="keria", salt=salter.qb64, temp=True) as hby:
+        hab = hby.makeHab("test01")
+        icp = hab.makeOwnInception()
 
-        assert natHab.kever.sn == 6
-        assert natHab.kever.fn == 6
-        assert natHab.kever.serder.said == 'EA3QbTpV15MvLSXHSedm4lRYdQhmYXqXafsD4i75B_yo'
-        ldig = bytes(natHab.db.getKeLast(dbing.snKey(natHab.pre, natHab.kever.sn)))
-        assert ldig == natHab.kever.serder.saidb
-        serder = serdering.SerderKERI(raw=bytes(natHab.db.getEvt(dbing.dgKey(natHab.pre, ldig))))
-        assert serder.said == natHab.kever.serder.said
-        nstate = natHab.kever.state()
+        icp = {
+            "v": "KERI10JSON00012b_",
+            "t": "icp",
+            "d": "EIvqOceOSGCMW4Ls-Wdi6t4K3RjKZU_DcHC_Q2w2jNs9",
+            "i": "EIvqOceOSGCMW4Ls-Wdi6t4K3RjKZU_DcHC_Q2w2jNs9",
+            "s": "0",
+            "kt": "1",
+            "k": ["DCwn62HEdsIbb0Tf-xTTR3fxZMQspc4iNbghK93Tfv1m"],
+            "nt": "1",
+            "n": ["EDzxxCBaWkzJ2Azn5HS50DZjslp-HMPeG6vGEm4AW168"],
+            "bt": "0",
+            "b": [],
+            "c": [],
+            "a": [],
+        }
 
-        state =natHab.db.states.get(keys=natHab.pre)  # key state record
-        assert state._asjson() == (b'{"vn":[1,0],"i":"EBm9JqQKS4a3EYv5I7BmAPiwhdSQvFAOpqe0dgk3kgH_","s":"6","p":"'
-                            b'ED_HpKSCQJoeGxHYjPRD2tgUhbIrLf6fH3e3xJFSq2dL","d":"EA3QbTpV15MvLSXHSedm4lRYd'
-                            b'QhmYXqXafsD4i75B_yo","f":"6","dt":"2021-01-01T00:00:00.000000+00:00","et":"i'
-                            b'xn","kt":"2","k":["DCORPGaoMtI_RyJFUTIzk0xdza_z6sBQ2e2wzYtEAs3s","DNjSHBbYJa'
-                            b'aUKJuPd34n7SRYiZHirwvW-QiHRtfRvBh4","DN-hL9CKn6WdsINEG207T4pSdjaMIxU9SKhfeeH'
-                            b'CwfvT"],"nt":"2","n":["EGZ9WHJPgrvDpe08gJpEZ8Gz-rcy72ZG7Tey0PS2CrXY","EO_z0O'
-                            b'FTUZ1pmfxj-VnQJcsYFdIVq2tWkN9nUWRxQab_","EMeWMAZpVy7IX6yl4F2t-WoUCaRFZ-0g5dx'
-                            b'_LLoEywhx"],"bt":"0","b":[],"c":[],"ee":{"s":"2","d":"EJ7s1vk30hWK_l-exQtzj4'
-                            b'P5u_wIzki1drVR4FAKDbEW","br":[],"ba":[]},"di":""}')
-        assert state.f == '6'
-        assert state == nstate
+        serder = serdering.SerderKERI(sad=icp, kind=eventing.Serials.json)
+        msg = serder.raw
 
-        # now create new Kever with state
-        kever = eventing.Kever(state=state, db=natHby.db)
-        assert kever.sn == 6
-        assert kever.fn == 6
-        assert kever.serder.ked == natHab.kever.serder.ked
-        assert kever.serder.said == natHab.kever.serder.said
+        queue = queueing.Queueing(hab=hab)
+        queue.push_to_queued(hab.pre, msg)
 
-        kstate = kever.state()
-        assert kstate == state
-        assert state._asjson() == (b'{"vn":[1,0],"i":"EBm9JqQKS4a3EYv5I7BmAPiwhdSQvFAOpqe0dgk3kgH_","s":"6","p":"'
-                            b'ED_HpKSCQJoeGxHYjPRD2tgUhbIrLf6fH3e3xJFSq2dL","d":"EA3QbTpV15MvLSXHSedm4lRYd'
-                            b'QhmYXqXafsD4i75B_yo","f":"6","dt":"2021-01-01T00:00:00.000000+00:00","et":"i'
-                            b'xn","kt":"2","k":["DCORPGaoMtI_RyJFUTIzk0xdza_z6sBQ2e2wzYtEAs3s","DNjSHBbYJa'
-                            b'aUKJuPd34n7SRYiZHirwvW-QiHRtfRvBh4","DN-hL9CKn6WdsINEG207T4pSdjaMIxU9SKhfeeH'
-                            b'CwfvT"],"nt":"2","n":["EGZ9WHJPgrvDpe08gJpEZ8Gz-rcy72ZG7Tey0PS2CrXY","EO_z0O'
-                            b'FTUZ1pmfxj-VnQJcsYFdIVq2tWkN9nUWRxQab_","EMeWMAZpVy7IX6yl4F2t-WoUCaRFZ-0g5dx'
-                            b'_LLoEywhx"],"bt":"0","b":[],"c":[],"ee":{"s":"2","d":"EJ7s1vk30hWK_l-exQtzj4'
-                            b'P5u_wIzki1drVR4FAKDbEW","br":[],"ba":[]},"di":""}')
+        # Verify push to queue then get serder from keys
+        assert queue.keldb_queued.get(hab.pre).raw == serder.raw
 
-    assert not os.path.exists(natHby.ks.path)
-    assert not os.path.exists(natHby.db.path)
-
-    """End Test"""
-
-
-def test_load_event(mockHelpingNowUTC):
-    with habbing.openHby(name="tor", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as torHby, \
-         habbing.openHby(name="wil", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as wilHby, \
-         habbing.openHby(name="wan", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as wanHby, \
-         habbing.openHby(name="tee", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as teeHby:
-
-        wanKvy = Kevery(db=wanHby.db, lax=False, local=False)
-        torKvy = Kevery(db=torHby.db, lax=False, local=False)
-
-        # Create Wan the witness
-        wanHab = wanHby.makeHab(name="wan", transferable=False)
-        assert wanHab.pre == "BAbSj3jfaeJbpuqg0WtvHw31UoRZOnN_RZQYBwbAqteP"
-        msg = wanHab.makeOwnEvent(sn=0)
-        parsing.Parser().parse(ims=msg, kvy=torKvy)
-        assert wanHab.pre in torKvy.kevers
-
-        # Create Wil the witness, we'll use him later
-        wilHab = wilHby.makeHab(name="wil", transferable=False)
-
-        # Create Tor the delegaTOR and pass to witness Wan
-        torHab = torHby.makeHab(name="tor", icount=1, isith='1', ncount=1, nsith='1', wits=[wanHab.pre], toad=1)
-        assert torHab.pre == "EBOVJXs0trI76PRfvJB2fsZ56PrtyR6HrUT9LOBra8VP"
-        torIcp = torHab.makeOwnEvent(sn=0)
-        assert torHab.pre in torHab.kvy.kevers
-
-        # Try to load event before Wan has seen it
-        with pytest.raises(ValueError):
-            _ = eventing.loadEvent(wanHab.db, torHab.pre, torHab.pre)
-
-        # tor events are locallyWitnessed by wan so must process as local
-        parsing.Parser().parse(ims=bytearray(torIcp), kvy=wanHab.kvy, local=True) # process as local
-
-        wanHab.processCues(wanHab.kvy.cues)  # process cue returns rct msg
-        evt = eventing.loadEvent(wanHab.db, torHab.pre, torHab.pre)
-        assert evt == {'ked': {'a': [],
-                               'b': ['BAbSj3jfaeJbpuqg0WtvHw31UoRZOnN_RZQYBwbAqteP'],
-                               'bt': '1',
-                               'c': [],
-                               'd': 'EBOVJXs0trI76PRfvJB2fsZ56PrtyR6HrUT9LOBra8VP',
-                               'i': 'EBOVJXs0trI76PRfvJB2fsZ56PrtyR6HrUT9LOBra8VP',
-                               'k': ['DDgZRj4y6XmkeCsjxLQ-WeAU_U0D3ttTBHW-yicX9hjT'],
-                               'kt': '1',
-                               'n': ['ED9aiBH7JDgWIgPU1bEXDx8XDFPCWKQilDNyw9W1sCl_'],
-                               'nt': '1',
-                               's': '0',
-                               't': 'icp',
-                               'v': 'KERI10JSON000159_'},
-                       'receipts': {},
-                       'signatures': [{'index': 0,
-                                       'signature': 'AAAa36fZASpQeSPn6cEcDMuXRCpDqjXbQ0Q6PqOXB_uktcuANR8rsRdpgB3A87XWeU'
-                                                    'QMB0MrWxUE-2bcjq5JJtMP'}],
-                       'stored': True,
-                       'timestamp': '2021-01-01T00:00:00.000000+00:00',
-                       'witness_signatures': [{'index': 0,
-                                               'signature': 'AAAU3Kk_Sgd_r4NX4MyE33-eAxM5fUS0WxIyId8YJ-wphNxMT5wI1Mz540'
-                                                            'EjYZRkrnty3VfkYhMv-XkGJuY-JWQI'}],
-                       'witnesses': ['BAbSj3jfaeJbpuqg0WtvHw31UoRZOnN_RZQYBwbAqteP']}
-
-        # Create Tee the delegaTEE and pass to witness Wan
-        teeHab = teeHby.makeHab(name="tee", delpre=torHab.pre, icount=1, isith='1', ncount=1, nsith='1',
-                                wits=[wanHab.pre], toad=1)
-        assert teeHab.pre == "EDnrWpxagMvr5BBCwCOh3q5M9lvurboZ66vxR-GnIgQo"
-        teeIcp = teeHab.makeOwnEvent(sn=0)
-
-        # Anchor Tee's inception event in Tor's KEL
-        ixn = torHab.interact(data=[dict(i=teeHab.pre, s='0', d=teeHab.kever.serder.said)])
-        parsing.Parser().parse(ims=bytearray(ixn), kvy=wanHab.kvy, local=True)  # give to wan must be local
-        wanHab.processCues(wanHab.kvy.cues)  # process cue returns rct msg
-
-        evt = eventing.loadEvent(wanHab.db, torHab.pre, torHab.kever.serder.said)
-        assert evt == {'ked': {'a': [{'d': 'EDnrWpxagMvr5BBCwCOh3q5M9lvurboZ66vxR-GnIgQo',
-                                      'i': 'EDnrWpxagMvr5BBCwCOh3q5M9lvurboZ66vxR-GnIgQo',
-                                      's': '0'}],
-                               'd': 'EF7pHYN6XABC9znRdzprt5frW-MMry9rfrCI-_t5Y8VD',
-                               'i': 'EBOVJXs0trI76PRfvJB2fsZ56PrtyR6HrUT9LOBra8VP',
-                               'p': 'EBOVJXs0trI76PRfvJB2fsZ56PrtyR6HrUT9LOBra8VP',
-                               's': '1',
-                               't': 'ixn',
-                               'v': 'KERI10JSON00013a_'},
-                       'receipts': {},
-                       'signatures': [{'index': 0,
-                                       'signature': 'AABw4jnfadT8aCwyGX2rDtOV8ojW4w4kVehFoJu_p6TzRpsayZ-cibTM_2iZfHVjWx'
-                                                    'zcIUbP2ibq6cVbVcOcNHsF'}],
-                       'stored': True,
-                       'timestamp': '2021-01-01T00:00:00.000000+00:00',
-                       'witness_signatures': [{'index': 0,
-                                               'signature': 'AABBQIanzXTUfATO36Q_ZzXSE4x2OlxC0MnOuyaUBE4bJhdHhV0f7qPIu5'
-                                                            'xClEH2C5AgWgLRPlQ-qo98qJHhIr0B'}],
-                       'witnesses': []}
-
-        # Add seal source couple to Tee's inception before sending to Wan
-        counter = coring.Counter(code=coring.CtrDex.SealSourceCouples,
-                                 count=1)
-        teeIcp.extend(counter.qb64b)
-        seqner = coring.Seqner(sn=torHab.kever.sn)
-        teeIcp.extend(seqner.qb64b)
-        teeIcp.extend(torHab.kever.serder.saidb)
-
-        # Endorse Tee's inception event with Tor's Hab just so we have trans receipts
-        rct = torHab.receipt(serder=teeHab.kever.serder)
-        nrct = wilHab.receipt(serder=teeHab.kever.serder)
-
-        # Now Wan should be ready for Tee's inception
-        parsing.Parser().parse(ims=bytearray(teeIcp), kvy=wanKvy, local=True)  # local
-        parsing.Parser().parse(ims=bytearray(rct), kvy=wanHab.kvy, local=True) # local
-        parsing.Parser().parse(ims=bytearray(nrct), kvy=wanHab.kvy, local=True)  # local
-        # ToDo XXXX fix it so cues are durable in db so can process cues from
-        # both and remote sources
-        wanHab.processCues(wanHab.kvy.cues)  # process cue returns rct msg
-        wanHab.processCues(wanKvy.cues)  # process cue returns rct msg
-
-        # Endorse Tee's inception event with Wan's Hab just so we have non-trans receipts
-
-        evt = eventing.loadEvent(wanHab.db, teeHab.pre, teeHab.pre)
-        assert evt == {'ked': {'a': [],
-                               'b': ['BAbSj3jfaeJbpuqg0WtvHw31UoRZOnN_RZQYBwbAqteP'],
-                               'bt': '1',
-                               'c': [],
-                               'd': 'EDnrWpxagMvr5BBCwCOh3q5M9lvurboZ66vxR-GnIgQo',
-                               'di': 'EBOVJXs0trI76PRfvJB2fsZ56PrtyR6HrUT9LOBra8VP',
-                               'i': 'EDnrWpxagMvr5BBCwCOh3q5M9lvurboZ66vxR-GnIgQo',
-                               'k': ['DLDlVl1H2Q138A5tftVRpyy834ejsY33BB71kXLRNP2h'],
-                               'kt': '1',
-                               'n': ['EBTtZqMkJOO4nf3cCt6SdezwkoCKtx2fGUKHeFApj_Yx'],
-                               'nt': '1',
-                               's': '0',
-                               't': 'dip',
-                               'v': 'KERI10JSON00018d_'},
-                       'receipts': {'nontransferable': [{'prefix': 'BEXrSXVksXpnfno_Di6RBX2Lsr9VWRAihjLhowfjNOQQ',
-                                                         'signature': '0BCQOeNT3mwAHxh6mYU9K_B2VmbtjJh7_8115k4JrBPR3c4'
-                                                                      '3jUSO197H2J73vWMi61qzOovNkSWQbnRx3NFnrk8I'}],
-                                    'transferable': [{'prefix': 'EBOVJXs0trI76PRfvJB2fsZ56PrtyR6HrUT9LOBra8VP',
-                                                      'said': 'EBOVJXs0trI76PRfvJB2fsZ56PrtyR6HrUT9LOBra8VP',
-                                                      'sequence': '0AAAAAAAAAAAAAAAAAAAAAAA',
-                                                      'signature': 'AADGbcmUNw_SX7OVNX-PQYl41UZx_pgJXHOoMWrcfmCDGgkc1-'
-                                                                   'MqXJjMD9S9moJ-lpPL9-AiXgITemMZL_QYGzIA'}]},
-                       'signatures': [{'index': 0,
-                                       'signature': 'AAC1-NTntZ0xkgHwooNcKxe9G4XC-rgkSryVz0B_QrZR2kkv4IKi7DMkfMBd4Eck-'
-                                                    '2NAi0DMuZeXnlvch6ZP0coO'}],
-                       'source_seal': {'said': 'EF7pHYN6XABC9znRdzprt5frW-MMry9rfrCI-_t5Y8VD',
-                                       'sequence': 1},
-                       'stored': True,
-                       'timestamp': '2021-01-01T00:00:00.000000+00:00',
-                       'witness_signatures': [{'index': 0,
-                                               'signature': 'AABPMW3J1iZyMC-elPOkdIhddhZB_BJYHTdYv5SxcrOfJL_5igDVB6zKD'
-                                                            'AQiTj_cNa7oP-l6xSRRxwlHDwqgSwcB'}],
-                       'witnesses': ['BAbSj3jfaeJbpuqg0WtvHw31UoRZOnN_RZQYBwbAqteP']}
-
-    """End Test"""
-
-
-if __name__ == "__main__":
-    # pytest.main(['-vv', 'test_eventing.py::test_keyeventfuncs'])
-    #test_process_manual()
-    #test_keyeventsequence_0()
-    #test_process_transferable()
-    #test_messagize()
-    test_direct_mode()

--- a/src/tests/test_queueing.py
+++ b/src/tests/test_queueing.py
@@ -44,112 +44,81 @@ def test_push_to_queued():
         msg = serder.raw
 
         queue = queueing.Queueing(hab=hab)
-        queue.push_to_queued(hab.pre, msg)
+        queue.pushToQueued(serder.pre, msg)
 
         # Verify push to queue then get serder from keys
-        assert queue.keldb_queued.get(hab.pre).raw == serder.raw
+        assert queue.keldb_queued.get((serder.pre, serder.said)).raw == serder.raw
 
 
-def test_fetch_push_t():
+def test_publish():
     salt = b"0123456789abcdef"
     salter = coring.Salter(raw=salt)
 
     with habbing.openHby(name="keria", salt=salter.qb64, temp=True) as hby:     
-        hab = hby.makeHab("test01", transferable=False)
-        
-        icp_1 = {
+        hab = hby.makeHab("test01", transferable=False)      
+
+        icp = {
             "v": "KERI10JSON00012b_",
             "t": "icp",
-            "d": "EIvqOceOSGCMW4Ls-Wdi6t4K3RjKZU_DcHC_Q2w2jNs9",
-            "i": "EIvqOceOSGCMW4Ls-Wdi6t4K3RjKZU_DcHC_Q2w2jNs9",
-            "s": "0",
-            "kt": "1",
-            "k": ["DCwn62HEdsIbb0Tf-xTTR3fxZMQspc4iNbghK93Tfv1m"],
-            "nt": "1",
-            "n": ["EDzxxCBaWkzJ2Azn5HS50DZjslp-HMPeG6vGEm4AW168"],
-            "bt": "0",
-            "b": [],
-            "c": [],
-            "a": [],
-        }
-
-        icp_2 = {
-            "v": "KERI10JSON0000fd_",
-            "t": "icp",
-            "d": "EP-4PeQ-5j1CG4MW2OrPQWbRcQ53IxEeiwqWP6IfXoom",
-            "i": "BCwn62HEdsIbb0Tf-xTTR3fxZMQspc4iNbghK93Tfv1m",
+            "d": "EMUZhB8shDE0I4kSa6Z688320bQwqWP3eZjnRoRJz7vn",
+            "i": "EMUZhB8shDE0I4kSa6Z688320bQwqWP3eZjnRoRJz7vn",
             "s": "0",
             "kt": "1",
             "k": [
-                "BCwn62HEdsIbb0Tf-xTTR3fxZMQspc4iNbghK93Tfv1m"
+                "DOVGajHFpHgoXB55a9Yn4fpTOTHGZEEjsxXX034OUmhh"
             ],
-            "nt": "0",
-            "n": [],
+            "nt": "1",
+            "n": [
+                "EOy1p9bw99tDqwLP6pnThrZ2zwKTxZCOqWgwtT6NQ9WY"
+            ],
             "bt": "0",
             "b": [],
             "c": [],
             "a": []
-            }
+        }        
 
-        serder_1 = serdering.SerderKERI(sad=icp_1, kind=eventing.Serials.json)
+        rot = {
+            "v": "KERI10JSON000160_",
+            "t": "rot",
+            "d": "ELC6knkUz5zhhFgXLBaQ9qW0jvJtD1d911f55_nffl2R",
+            "i": "EMUZhB8shDE0I4kSa6Z688320bQwqWP3eZjnRoRJz7vn",
+            "s": "1",
+            "p": "EMUZhB8shDE0I4kSa6Z688320bQwqWP3eZjnRoRJz7vn",
+            "kt": "1",
+            "k": [
+                "DFq9W4cH7BD77m8NJM2XN4iGz6uoGGQb7KklJNM-AQbG"
+            ],
+            "nt": "1",
+            "n": [
+                "ELwL_SJ_p4WQGDAqYBjEGYjZvJIdHSXOVULaA7N6lZzZ"
+            ],
+            "bt": "0",
+            "br": [],
+            "ba": [],
+            "a": []
+        }
+
+        serder_1 = serdering.SerderKERI(sad=icp, kind=eventing.Serials.json)
         msg_1 = serder_1.raw
-        serder_2 = serdering.SerderKERI(sad=icp_2, kind=eventing.Serials.json)
+        serder_2 = serdering.SerderKERI(sad=rot, kind=eventing.Serials.json)
         msg_2 = serder_2.raw
 
         queue = queueing.Queueing(hab=hab)
-        queue.push_to_queued(f"{hab.pre}_1", msg_1)
-        queue.push_to_queued(f"{hab.pre}_2", msg_2)
+        queue.pushToQueued(serder_1.pre, msg_1)
+        queue.pushToQueued(serder_2.pre, msg_2)
 
         # Verify keldb_queued had events
-        keldb_queued_items = [(pre, serder) for (pre,), serder in queue.keldb_queued.getItemIter()]
+        keldb_queued_items = [(pre, serder) for (pre, _), serder in queue.keldb_queued.getItemIter()]
         assert keldb_queued_items != []
 
         queue.publish()
 
         # Verify keldb_queued published and remove from keldb_queued
-        keldb_queued_items = [ (pre, serder) for (pre, ), serder in queue.keldb_queued.getItemIter()]
+        keldb_queued_items = [ (pre, serder) for (pre, _), serder in queue.keldb_queued.getItemIter()]
         assert keldb_queued_items == []
 
         # Verify event published and keldb_published had events from keldb_queued
-        keldb_published = [(pre, serder) for (pre,), serder in queue.keldb_published.getItemIter()]
+        keldb_published = [(pre, serder) for (pre, _), serder in queue.keldb_published.getItemIter()]
         assert keldb_published != []
-
-
-def test_http_call():
-    salter = Salter(raw=b'0123456789abcdef')
-
-    with openDB(name="edy") as db, openKS(name="edy") as ks, habbing.openHby(name="keria", salt=salter.qb64, temp=True) as hby:
-        # Init key pair manager
-        hab = hby.makeHab("test02")
-        mgr = Manager(ks=ks, salt=salter.qb64)
-        verfers, _ = mgr.incept(icount=1, ncount=0, transferable=True, stem="C")
-        qry = hab.query(pre=hab.pre, src=hab.pre, route="/log")
-        serder = serdering.SerderKERI(raw=qry)
-        sigers = mgr.sign(ser=serder.raw, verfers=verfers)  # default indexed True
-        assert isinstance(sigers[0], Siger)
-
-        qserder = query(route="log",
-                        query=dict(i='DAvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI'),
-                        stamp=help.helping.DTS_BASE_0)
-        msg = qserder.raw
-        CESR_CONTENT_TYPE = "application/cesr+json"
-        CESR_ATTACHMENT_HEADER = "CESR-ATTACHMENT"
-        CESR_DESTINATION_HEADER = "CESR-DESTINATION"
-        attachment = b'-VAj-HABEIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3-AABAAB6P97k'
-
-        headers = Hict(
-            [
-                ("Content-Type", CESR_CONTENT_TYPE),
-                ("Content-Length", str(len(msg))),
-                (CESR_ATTACHMENT_HEADER, attachment),
-                (
-                    CESR_DESTINATION_HEADER,
-                    "BD27gP7-sD8XSr7_tTo54aNIRzPBJGX7GvRUVojfYL2H",
-                ),
-            ]
-        )
-
-        res = requests.request(
-            "POST", "http://localhost:5666/", headers=headers, data=msg
-        )
-        assert res.status_code == 204
+        assert keldb_published[0][1].said == rot['d']
+        assert keldb_published[1][1].said == icp['d']

--- a/src/tests/test_queueing.py
+++ b/src/tests/test_queueing.py
@@ -74,3 +74,81 @@ def test_push_to_queued():
         # Verify push to queue then get serder from keys
         assert queue.keldb_queued.get(hab.pre).raw == serder.raw
 
+
+def test_push_to_queued():
+    salt = b"0123456789abcdef"
+    salter = coring.Salter(raw=salt)
+
+    with habbing.openHby(name="keria", salt=salter.qb64, temp=True) as hby:
+        hab = hby.makeHab("test01")
+        icp = hab.makeOwnInception()
+
+        icp = {
+            "v": "KERI10JSON00012b_",
+            "t": "icp",
+            "d": "EIvqOceOSGCMW4Ls-Wdi6t4K3RjKZU_DcHC_Q2w2jNs9",
+            "i": "EIvqOceOSGCMW4Ls-Wdi6t4K3RjKZU_DcHC_Q2w2jNs9",
+            "s": "0",
+            "kt": "1",
+            "k": ["DCwn62HEdsIbb0Tf-xTTR3fxZMQspc4iNbghK93Tfv1m"],
+            "nt": "1",
+            "n": ["EDzxxCBaWkzJ2Azn5HS50DZjslp-HMPeG6vGEm4AW168"],
+            "bt": "0",
+            "b": [],
+            "c": [],
+            "a": [],
+        }
+
+        serder = serdering.SerderKERI(sad=icp, kind=eventing.Serials.json)
+        msg = serder.raw
+
+        queue = queueing.Queueing(hab=hab)
+        queue.push_to_queued(hab.pre, msg)
+
+        # Verify push to queue then get serder from keys
+        assert queue.keldb_queued.get(hab.pre).raw == serder.raw
+
+
+def test_fetch_push_t():
+    salt = b"0123456789abcdef"
+    salter = coring.Salter(raw=salt)
+
+    with habbing.openHby(name="keria", salt=salter.qb64, temp=True) as hby:
+        hab = hby.makeHab("test01")
+        icp = hab.makeOwnInception()
+
+        icp = {
+            "v": "KERI10JSON00012b_",
+            "t": "icp",
+            "d": "EIvqOceOSGCMW4Ls-Wdi6t4K3RjKZU_DcHC_Q2w2jNs9",
+            "i": "EIvqOceOSGCMW4Ls-Wdi6t4K3RjKZU_DcHC_Q2w2jNs9",
+            "s": "0",
+            "kt": "1",
+            "k": ["DCwn62HEdsIbb0Tf-xTTR3fxZMQspc4iNbghK93Tfv1m"],
+            "nt": "1",
+            "n": ["EDzxxCBaWkzJ2Azn5HS50DZjslp-HMPeG6vGEm4AW168"],
+            "bt": "0",
+            "b": [],
+            "c": [],
+            "a": [],
+        }
+
+        serder = serdering.SerderKERI(sad=icp, kind=eventing.Serials.json)
+        msg = serder.raw
+
+        queue = queueing.Queueing(hab=hab)
+        queue.push_to_queued(hab.pre, msg)
+
+        # Verify keldb_queued had events
+        keldb_queued_items = [(pre, serder) for (pre,), serder in queue.keldb_queued.getItemIter()]
+        assert keldb_queued_items != []
+
+        queue.publish()
+
+        # Verify keldb_queued published and remove from keldb_queued
+        keldb_queued_items = [ (pre, serder) for (pre, ), serder in queue.keldb_queued.getItemIter()]
+        assert keldb_queued_items == []
+
+        # Verify event published and keldb_published had events from keldb_queued
+        keldb_published = [(pre, serder) for (pre,), serder in queue.keldb_published.getItemIter()]
+        assert keldb_published != []


### PR DESCRIPTION
## Context
- publishEvent for the cardano-backer is a variable that gets replaced every call. This was previously an object which could work as a queue, but it had the same issue as before where it was all in memory.

## Change
- Add the queue service with push to queue, and publish to on-chain action
- Add two sub-dbs

## Ticket
- [DTIS-967](https://cardanofoundation.atlassian.net/browse/DTIS-967)